### PR TITLE
Update: match BOM first, then check likely UTF8

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,13 +10,17 @@
 var isUTF8 = require('is-utf8');
 var isBuffer = require('is-buffer');
 
+function matchBOM(buf) {
+  return buf[0] === 0xEF && buf[1] === 0xBB && buf[2] === 0xBF;
+}
+
 function maybeUTF8(buf) {
   // Only "maybe" because we aren't sniffing the whole buffer
-  return isUTF8(buf.slice(0, 7));
+  return isUTF8(buf.slice(3, 7));
 }
 
 module.exports = function(buf) {
-  if (isBuffer(buf) && maybeUTF8(buf) && String(buf.slice(0, 3)) === '\ufeff') {
+  if (isBuffer(buf) && matchBOM(buf) && maybeUTF8(buf)) {
     return buf.slice(3);
   }
   return buf;


### PR DESCRIPTION
I would like to propose a little addition to @phated's [PR](https://github.com/jonschlinkert/remove-bom-buffer/pull/3):
- Match the UTF8 BOM byte for byte, instead of decoding them to a string first.
- Don't call `maybeUTF8` unless we've established that the leading 3 bytes match UTF8 BOM.
- Don't pass the leading 3 bytes, which we already know at that point to be valid UTF8, on to `isUTF8`.

Hope this makes sense?